### PR TITLE
Refactor file passing, add deployment profiles, and include Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ work/*
 */.DS_Store
 input/.DS_Store
 output/
-docker/
 andyM_exemplar/
 .RData
 .Rhistory
+WHATIDID.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM r-base:4.3.3
+WORKDIR /app
+RUN apt-get update && \
+  apt-get install -y libxml2-dev
+
+# install general packages 
+#RUN apt-get -y install libcurl4-openssl-dev
+#RUN apt-get -y install libssl-dev
+#RUN apt-get -y install python3 python3-pip
+RUN set -xe \
+    && apt-get update \
+    && apt-get -o Dpkg::Options::="--force-overwrite" install python3-pip -y
+RUN python3 -m pip install --upgrade pip --break-system-packages 
+RUN pip --version
+RUN apt-get install -y procps
+
+# Install required python libraries
+COPY requirements-pip.txt .
+RUN pip install --no-cache-dir --upgrade pip --break-system-packages  \
+  && pip install --no-cache-dir -r requirements-pip.txt --break-system-packages 
+
+# Install R packages from binary (much quicker than using install.packages)
+COPY ./requirements-rbin.txt .
+RUN cat requirements-rbin.txt | xargs apt-get install -y -qq
+
+# Install any chosen R packages that aren't available as binaries
+COPY ./requirements-src.R .
+RUN Rscript requirements-src.R
+
+
+
+

--- a/docker/Dockerfile_old
+++ b/docker/Dockerfile_old
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+
+# install app dependencies
+RUN apt-get update && apt-get install -y python3 python3-pip
+RUN pip install flask==3.0.*
+
+# install app
+COPY hello.py /
+
+# final configuration
+ENV FLASK_APP=hello
+EXPOSE 8000
+CMD ["flask", "run", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/requirements-pip.txt
+++ b/docker/requirements-pip.txt
@@ -1,0 +1,4 @@
+numpy
+scikit-learn
+matplotlib
+pandas

--- a/docker/requirements-rbin.txt
+++ b/docker/requirements-rbin.txt
@@ -1,0 +1,12 @@
+
+r-cran-tidyverse
+r-cran-e1071
+r-cran-pracma
+r-cran-pheatmap
+r-cran-ggpubr
+r-cran-vcd
+r-cran-viridis
+r-cran-proc
+r-cran-upsetr
+r-bioc-deseq2
+r-bioc-edger

--- a/docker/requirements-src.R
+++ b/docker/requirements-src.R
@@ -1,0 +1,6 @@
+pkgs <- c(
+    'ggplotify',
+    'BiocManager'
+)
+install.packages(pkgs)
+BiocManager::install("compcodeR")

--- a/main.nf
+++ b/main.nf
@@ -77,8 +77,8 @@ workflow {
   println("Reference level: " + ch_reflevel)
 
   // Set a vector of depths across which to generate fullsynth datasets
-  depths = Channel.from(1E+5, 1E+6, 1E+7)
-  dummypath = Channel.fromPath("0")
+  depths = channel.from(1E+5, 1E+6, 1E+7)
+  dummypath = channel.fromPath("0")
 
   //Initial data QC and cleanup
   CLEANINPUTS(ch_samplesheet, ch_countsframe, ch_reflevel)
@@ -96,7 +96,7 @@ workflow {
   }
 
   ////Permutation analysis with no true signal
-  perms = Channel.from(1..params.nperms)
+  perms = channel.from(1..params.nperms)
   DATA_PERMUTE(CLEANINPUTS.out, perms)
   // For DESeq
   DESEQ_PERMUTE(DATA_PERMUTE.out.frames)

--- a/modules/create_breaks.nf
+++ b/modules/create_breaks.nf
@@ -10,6 +10,7 @@ process CREATE_BREAKS {
   //env refouts, emit: refouts
   //env altouts, emit: altouts
 
+  script:
   """
   #!/usr/bin/env Rscript
   library("tidyverse", quietly = TRUE)

--- a/modules/fullsynth_plots.nf
+++ b/modules/fullsynth_plots.nf
@@ -12,6 +12,7 @@ process FULLSYNTH_PLOTS {
     output:
     path "synth_plot.pdf"
 
+    script:
     """
     #!/usr/bin/env Rscript
     library("tidyverse", quietly = TRUE)

--- a/modules/fullsynth_plots.nf
+++ b/modules/fullsynth_plots.nf
@@ -3,11 +3,10 @@ process FULLSYNTH_PLOTS {
     publishDir "$params.outdir"
 
     input:
-    val deseq_synths
-    val edger_synths
-    val wilcox_synths
-    val svc_synths
-
+    path(deseq_synths,  stageAs: 'deseq/outframe_?.csv')
+    path(edger_synths,  stageAs: 'edger/outframe_?.csv')
+    path(wilcox_synths, stageAs: 'wilcox/outframe_?.csv')
+    path(svc_synths,    stageAs: 'svc/outframe_?.csv')
 
     output:
     path "synth_plot.pdf"
@@ -19,82 +18,59 @@ process FULLSYNTH_PLOTS {
     library("reshape2", quietly = TRUE)
     library("viridis")
 
-    # reading function for lists of fullsynth output files
-    read_fullsynths = function(inlist, label){
-        
-        this.inlist <- str_remove_all(inlist,"[\\\\[\\\\] ]") %>% 
-            strsplit(split = ",") %>% unlist()
-        
-        out <- sapply(this.inlist, read.csv) %>% 
-            t() %>% 
-            `row.names<-`(NULL) %>% 
-            data.frame() %>%
-            mutate_at(c("power","FDP","normAUC","samplenum","depth"),as.numeric) %>%
-            mutate(method = label) %>% 
-            melt(id.vars = c("method","samplenum", "depth"))
-
-        return(out) 
-        
+    read_fullsynths = function(dir, label){
+        lapply(list.files(dir, full.names = TRUE), read.csv) %>%
+            bind_rows() %>%
+            mutate(method = label) %>%
+            melt(id.vars = c("method", "samplenum", "depth"))
     }
 
-    deseq.synth.input = read_fullsynths("$deseq_synths", "DESeq2")
-    edger.synth.input = read_fullsynths("$edger_synths", "edgeR")
-    wilcox.synth.input = read_fullsynths("$wilcox_synths", "Wilcoxon")
-    # Only include ML outputs if specified by user
+    deseq.synth.input  = read_fullsynths("deseq",  "DESeq2")
+    edger.synth.input  = read_fullsynths("edger",  "edgeR")
+    wilcox.synth.input = read_fullsynths("wilcox", "Wilcoxon")
+
     if("$params.mlstep" == "true"){
-        svc.synth.input = read_fullsynths("$svc_synths", "SVC")
-
-        gg.synth.input = rbind(deseq.synth.input, 
-                            edger.synth.input,
-                            wilcox.synth.input,
-                            svc.synth.input) %>% 
-            mutate(samplenum = as.factor(samplenum)) %>%
-            mutate(depth = as.factor(depth)) %>%
-            group_by(method,samplenum,depth,variable) %>% 
-            summarize(mean=mean(value)) %>%
-            mutate(mean = signif(mean,3))
+        svc.synth.input = read_fullsynths("svc", "SVC")
+        gg.synth.input = rbind(deseq.synth.input,
+                               edger.synth.input,
+                               wilcox.synth.input,
+                               svc.synth.input)
     } else {
-        gg.synth.input = rbind(deseq.synth.input, 
-                        edger.synth.input,
-                        wilcox.synth.input) %>% 
-        mutate(samplenum = as.factor(samplenum)) %>%
-        mutate(depth = as.factor(depth)) %>%
-        group_by(method,samplenum,depth,variable) %>% 
-        summarize(mean=mean(value)) %>%
-        mutate(mean = signif(mean,3))
-        
+        gg.synth.input = rbind(deseq.synth.input,
+                               edger.synth.input,
+                               wilcox.synth.input)
     }
 
+    gg.synth.input = gg.synth.input %>%
+        mutate(samplenum = as.factor(samplenum),
+               depth     = as.factor(depth)) %>%
+        group_by(method, samplenum, depth, variable) %>%
+        summarize(mean = mean(value)) %>%
+        mutate(mean = signif(mean, 3))
 
-    # Take FDP as inverse (1-FDP), so that higher values are better (matching to power and normAUC)
-    gg.synth.input\$mean[which(gg.synth.input\$variable == "FDP")] = 1-(gg.synth.input\$mean[which(gg.synth.input\$variable == "FDP")])
-    gg.synth.input\$variable = fct_recode(gg.synth.input\$variable, "1-FDP"="FDP")
-    
-    # Plot as heatmap    
+    # Take FDP as inverse so higher values are better (matches power and normAUC)
+    gg.synth.input\$mean[which(gg.synth.input\$variable == "FDP")] =
+        1 - gg.synth.input\$mean[which(gg.synth.input\$variable == "FDP")]
+    gg.synth.input\$variable = fct_recode(gg.synth.input\$variable, "1-FDP" = "FDP")
+
     gg.synth = ggplot(gg.synth.input, aes(x = depth, y = samplenum)) +
-        geom_tile(aes(fill = mean),color = "gray20", size=.75, width=1, height = 1)+
-        geom_label(aes(label= mean), color = "white",
-                    lineheight = 0.75, size = 3.5, alpha = 0.7, fill = "gray10") +
-        scale_x_discrete("Sequencing depth",
-                        expand = c(0,0)) +
-        scale_y_discrete("Replicates per treatment",
-                        expand = c(0,0)) +
-        scale_fill_viridis(option = "plasma", 
-                            limits = c(0,1),
-                            expand = c(0,0)) +
-        facet_grid(variable~method) +
+        geom_tile(aes(fill = mean), color = "gray20", size = .75, width = 1, height = 1) +
+        geom_label(aes(label = mean), color = "white",
+                   lineheight = 0.75, size = 3.5, alpha = 0.7, fill = "gray10") +
+        scale_x_discrete("Sequencing depth",  expand = c(0, 0)) +
+        scale_y_discrete("Replicates per treatment", expand = c(0, 0)) +
+        scale_fill_viridis(option = "plasma", limits = c(0, 1), expand = c(0, 0)) +
+        facet_grid(variable ~ method) +
         theme_bw() +
-        theme(panel.grid = element_blank(),
-                legend.title = element_text(face = "bold"),
-                axis.text = element_text(face = "bold",size =11, color = "grey40"),
-                axis.title = element_text(face = "bold", size =12))
+        theme(panel.grid      = element_blank(),
+              legend.title    = element_text(face = "bold"),
+              axis.text       = element_text(face = "bold", size = 11, color = "grey40"),
+              axis.title      = element_text(face = "bold", size = 12))
 
-    #set save width based on number of methods tried
-    widthvar = 10*(length(unique(gg.synth.input\$method)))
-
-    ggsave(gg.synth, 
-        filename = "synth_plot.pdf",
-        device = "pdf", bg = "transparent",
-        width = widthvar, height = 30, units = "cm")
+    ggsave(gg.synth,
+           filename = "synth_plot.pdf",
+           device = "pdf", bg = "transparent",
+           width  = 10 * length(unique(gg.synth.input\$method)),
+           height = 30, units = "cm")
     """
 }

--- a/modules/inter_observer_basic.nf
+++ b/modules/inter_observer_basic.nf
@@ -17,6 +17,7 @@ process INTER_OBSERVER_BASIC{
   path "basic_overlap_violins.pdf"
   path "deseq_poorfits.RData", emit: deseq_poorfits
 
+    script:
     """
     #!/usr/bin/env Rscript
     library("tidyverse", quietly = TRUE)

--- a/modules/permute_hists.nf
+++ b/modules/permute_hists.nf
@@ -2,11 +2,11 @@ process PERMUTE_HISTS{
 
   publishDir "$params.outdir"
 
-  input: 
-  val deseq_infiles
-  val edger_infiles
-  val wilcox_infiles
-  val SVC_infiles
+  input:
+  path(deseq_infiles,  stageAs: 'deseq/deseq_table_?.csv')
+  path(edger_infiles,  stageAs: 'edger/edger_table_?.csv')
+  path(wilcox_infiles, stageAs: 'wilcox/wilcox_table_?.csv')
+  path(SVC_infiles,    stageAs: 'svc/svc_table_?.csv')
   path deseq_poorfits
 
   output:
@@ -20,150 +20,107 @@ process PERMUTE_HISTS{
   library("reshape2", quietly = TRUE)
   library("ggpubr")
 
-
   nperms = as.numeric("$params.nperms")
 
-  # Function to read in tables produced by R
-  readfun = function(x){
-    res <- read.csv(x,row.names = 1)
-    df <- data.frame(result = (res\$padj<0.05), row.names = row.names(res))
-    return(df)
+  read_permdegs_r = function(dir){
+    lapply(list.files(dir, full.names = TRUE), function(x){
+      res <- read.csv(x, row.names = 1)
+      data.frame(result = (res\$padj < 0.05), row.names = row.names(res))
+    }) %>% list_cbind() %>% rowSums(na.rm = TRUE)
   }
 
-  # Function to read in files produced by Python
-  pythout_readfun = function(x){
-    res <- read.csv(x,row.names = 1)
-    df <- data.frame(result = (res\$DEGstatus==1), row.names = row.names(res))
-    return(df)
+  read_permdegs_py = function(dir){
+    lapply(list.files(dir, full.names = TRUE), function(x){
+      res <- read.csv(x, row.names = 1)
+      data.frame(result = (res\$DEGstatus == 1), row.names = row.names(res))
+    }) %>% list_cbind() %>% rowSums(na.rm = TRUE)
   }
 
-  deseq.inlist = str_remove_all("$deseq_infiles","[\\\\[\\\\] ]") %>% 
-    strsplit(split = ",") %>% unlist()
-  deseq.permdegs = lapply(deseq.inlist,readfun) %>% 
-    list_cbind() %>%
-    rowSums(na.rm=TRUE)
+  deseq.permdegs  = read_permdegs_r("deseq")
+  edger.permdegs  = read_permdegs_r("edger")
+  wilcox.permdegs = read_permdegs_r("wilcox")
 
-  edger.inlist = str_remove_all("$edger_infiles","[\\\\[\\\\] ]") %>% 
-    strsplit(split = ",") %>% unlist()
-  edger.permdegs = lapply(edger.inlist,readfun) %>% 
-    list_cbind() %>%
-    rowSums(na.rm=TRUE)
-
-  wilcox.inlist = str_remove_all("$wilcox_infiles","[\\\\[\\\\] ]") %>% 
-    strsplit(split = ",") %>% unlist()
-  wilcox.permdegs = lapply(wilcox.inlist,readfun) %>% 
-    list_cbind() %>%
-    rowSums(na.rm=TRUE)
-
-  # Only include ML outputs if specified by user
   if("$params.mlstep" == "true"){
-    SVC.inlist = str_remove_all("$SVC_infiles","[\\\\[\\\\] ]") %>% 
-      strsplit(split = ",") %>% unlist()
-    SVC.permdegs = lapply(SVC.inlist,pythout_readfun) %>% 
-      list_cbind() %>%
-      rowSums(na.rm=TRUE)
-    
+    SVC.permdegs = read_permdegs_py("svc")
     permhist.in = cbind(deseq.permdegs,
                         edger.permdegs,
                         wilcox.permdegs,
                         SVC.permdegs) %>%
-      `colnames<-`(c("DESeq2",
-                    "edgeR",
-                    "Wilcoxon",
-                    "SVC")) %>%
+      `colnames<-`(c("DESeq2", "edgeR", "Wilcoxon", "SVC")) %>%
       melt()
   } else {
     permhist.in = cbind(deseq.permdegs,
                         edger.permdegs,
                         wilcox.permdegs) %>%
-      `colnames<-`(c("DESeq2",
-                    "edgeR",
-                    "Wilcoxon")) %>%
+      `colnames<-`(c("DESeq2", "edgeR", "Wilcoxon")) %>%
       melt()
-}
+  }
 
-
-  # Generate breaks contingent on number of reps
-  cutbreaks = cut(seq(1,nperms+1),breaks = 5, right = TRUE) %>% levels() %>%
+  # Generate breaks contingent on number of perms
+  cutbreaks = cut(seq(1, nperms + 1), breaks = 5, right = TRUE) %>% levels() %>%
     str_match("\\\\([^,]*") %>%
     str_remove("\\\\(") %>%
     as.numeric() %>%
     round()
-  #deal with an idiosyncrasy that causes cut to return 0 as the start value of the first bin instead of 1
   cutbreaks[1] = 1
-  
-  #plot
+
   gg.permhist = ggplot(permhist.in, aes(x = value)) +
     geom_histogram(color = "black", fill = "white", bins = 100) +
-    scale_x_continuous(limits = c(-1,(nperms+1)), breaks = cutbreaks) +
+    scale_x_continuous(limits = c(-1, (nperms + 1)), breaks = cutbreaks) +
     labs(x = "Number of permutations in which gene was\nincorrectly identified as a DEG",
          y = "Number of genes") +
     theme_bw() +
     facet_grid(~Var2) +
     theme(strip.background = element_blank())
 
-  ggsave(gg.permhist, 
+  ggsave(gg.permhist,
    filename = "permute_hist.pdf",
    device = "pdf", bg = "transparent",
-   width =  30, height = 20, units = "cm")
-   
-  # Also here we can run the check where we see if frequently misidentified genes tend to be nonbinomial
-  # This is only really meaningful when we have a large-ish number of permutations, but we'll do it with fewer for testing purposes
-  if(nperms >= 5){
-    
-    floor = nperms/1000 # Genes that are misattributed less than this often are 'trustworthy'
-    ceiling = nperms/5 # Genes that are misattributed more than this often are 'untrustworthy'
-    
-    permhist.deseq = subset(permhist.in, Var2 == "DESeq2")
-    deseq.trust = subset(permhist.deseq, value<=floor)
-    deseq.untrust = subset(permhist.deseq, value>=ceiling)
-    
-    #load poorness-of-fit data for deseq2 
-    deseq.poorfits = get(load("$deseq_poorfits"))
-    
-    # NB dummy NAs are appended here to prevent errors occurring when there are 0 '(un)trustworthy' genes
-    deseq.trust = rbind(
-      data.frame(poorfit = c(deseq.poorfits[deseq.trust\$Var1],NA), val = "Trustworthy"),
-      data.frame(poorfit = c(deseq.poorfits[deseq.untrust\$Var1],NA), val = "Untrustworthy")
-    ) %>% mutate(method = "DESeq2")
-    
-    permhist.edger = subset(permhist.in, Var2 == "edgeR")
-    edger.trust = subset(permhist.edger, value<=floor)
-    edger.untrust = subset(permhist.edger, value>=ceiling)
-    
-    #TODO: load poorness-of-fit data for edger instead of using DESeq fits here
-    #edger.poorfits = get(load("/Users/benjamin/Repositories/Zuzu/work/c5/cbd7b1c7e36c0109c2bff8a91b63be/edger_poorfits.RData"))
-    
-    edger.trust = rbind(
-      data.frame(poorfit = c(deseq.poorfits[edger.trust\$Var1],NA), val = "Trustworthy"),
-      data.frame(poorfit = c(deseq.poorfits[edger.untrust\$Var1],NA), val = "Untrustworthy")
-    ) %>% mutate(method = "edgeR")
-    
-    trustcomp = rbind(deseq.trust,edger.trust)
-    
-    gg.deseq.trust = 
-      ggplot(trustcomp, aes(x = as.factor(val), y = poorfit)) +
-      geom_violin() + 
-      labs(x = "Gene reliability",
-          y = "Poorness of fit to Negative Binomial distribution") +
-      stat_compare_means(method = "wilcox.test",
-                        label = "p.signif",
-                        size = 5,
-                        comparisons = list(c("Trustworthy","Untrustworthy"))) + #,
-    #label.y = c(0.31, 0.275, 0.255) +
-    facet_wrap(~ method) +
-    theme_bw() 
+   width = 30, height = 20, units = "cm")
 
-    ggsave(gg.deseq.trust, 
+  if(nperms >= 5){
+
+    floor   = nperms / 1000
+    ceiling = nperms / 5
+
+    permhist.deseq  = subset(permhist.in, Var2 == "DESeq2")
+    deseq.trust     = subset(permhist.deseq, value <= floor)
+    deseq.untrust   = subset(permhist.deseq, value >= ceiling)
+
+    deseq.poorfits = get(load("$deseq_poorfits"))
+
+    # NB dummy NAs prevent errors when there are 0 (un)trustworthy genes
+    permhist.edger = subset(permhist.in, Var2 == "edgeR")
+    edger.trust    = subset(permhist.edger, value <= floor)
+    edger.untrust  = subset(permhist.edger, value >= ceiling)
+
+    trustcomp = rbind(
+      data.frame(poorfit = c(deseq.poorfits[deseq.trust\$Var1],   NA), val = "Trustworthy",   method = "DESeq2"),
+      data.frame(poorfit = c(deseq.poorfits[deseq.untrust\$Var1], NA), val = "Untrustworthy", method = "DESeq2"),
+      data.frame(poorfit = c(deseq.poorfits[edger.trust\$Var1],   NA), val = "Trustworthy",   method = "edgeR"),
+      data.frame(poorfit = c(deseq.poorfits[edger.untrust\$Var1], NA), val = "Untrustworthy", method = "edgeR")
+    )
+
+    gg.deseq.trust =
+      ggplot(trustcomp, aes(x = as.factor(val), y = poorfit)) +
+      geom_violin() +
+      labs(x = "Gene reliability",
+           y = "Poorness of fit to Negative Binomial distribution") +
+      stat_compare_means(method = "wilcox.test",
+                         label = "p.signif",
+                         size = 5,
+                         comparisons = list(c("Trustworthy", "Untrustworthy"))) +
+      facet_wrap(~ method) +
+      theme_bw()
+
+    ggsave(gg.deseq.trust,
           filename = "permute_violins.pdf",
           device = "pdf", bg = "transparent",
-          width =  20, height = 12, units = "cm")
+          width = 20, height = 12, units = "cm")
 
   } else {
-  # If not enough perms, fool nextflow with dummy output 
     dummy = NA
-    save(dummy , file = "permute_violins.pdf")
+    save(dummy, file = "permute_violins.pdf")
   }
-
   """
 }

--- a/modules/permute_plots.nf
+++ b/modules/permute_plots.nf
@@ -17,6 +17,7 @@ process PERMUTE_PLOTS{
   output:
   path "permute_plot.pdf"
 
+  script:
   """
   #!/usr/bin/env Rscript
   library("tidyverse", quietly = TRUE)

--- a/modules/quasi_plots.nf
+++ b/modules/quasi_plots.nf
@@ -3,10 +3,10 @@ process QUASI_PLOTS{
   publishDir "$params.outdir"
 
   input:
-  val deseq_quasis
-  val edger_quasis
-  val wilcox_quasis
-  val svm_quasis
+  path(deseq_quasis,  stageAs: 'deseq/outframe_?.csv')
+  path(edger_quasis,  stageAs: 'edger/outframe_?.csv')
+  path(wilcox_quasis, stageAs: 'wilcox/outframe_?.csv')
+  path(svm_quasis,    stageAs: 'svc/outframe_?.csv')
 
   output:
   path "quasi_plot.pdf"
@@ -17,77 +17,31 @@ process QUASI_PLOTS{
   library("tidyverse", quietly = TRUE)
   library("reshape2", quietly = TRUE)
 
-  deseq.inlist = str_remove_all("$deseq_quasis","[\\\\[\\\\] ]") %>% 
-    strsplit(split = ",") %>% unlist()
+  read_quasis = function(dir, label){
+    lapply(list.files(dir, full.names = TRUE), read.csv) %>%
+      bind_rows() %>%
+      mutate_all(as.numeric) %>%
+      mutate(method = label) %>%
+      melt(id.vars = c("method", "samplenum"))
+  }
 
-  deseq.quasi.input = 
-    sapply(deseq.inlist, read.csv) %>% 
-    t() %>% 
-    `row.names<-`(NULL) %>% 
-    data.frame() %>%
-    mutate_all(as.numeric) %>%
-    mutate(method = "DESeq2") %>% 
-    melt(id.vars = c("method","samplenum"))
-
-  edger.inlist = str_remove_all("$edger_quasis","[\\\\[\\\\] ]") %>% 
-    strsplit(split = ",") %>% unlist()
-
-  edger.quasi.input = 
-    sapply(edger.inlist, read.csv) %>% 
-    t() %>% 
-    `row.names<-`(NULL) %>% 
-    data.frame() %>%
-    mutate_all(as.numeric) %>%
-    mutate(method = "edgeR") %>% 
-    melt(id.vars = c("method","samplenum"))
-
-  wilcox.inlist = str_remove_all("$wilcox_quasis","[\\\\[\\\\] ]") %>% 
-    strsplit(split = ",") %>% unlist()
-
-  wilcox.quasi.input = 
-    sapply(wilcox.inlist, read.csv) %>% 
-    t() %>% 
-    `row.names<-`(NULL) %>% 
-    data.frame() %>%
-    mutate_all(as.numeric) %>%
-    mutate(method = "wilcox") %>% 
-    melt(id.vars = c("method","samplenum"))
-        
-#  # Only include ML outputs if specified by user
-#  if("$params.mlstep" == "true"){
-#    svm.inlist = str_remove_all("$svm_quasis","[\\\\[\\\\] ]") %>% 
-#      strsplit(split = ",") %>% unlist()
-#
-#    svm.quasi.input = 
-#      sapply(svm.inlist, read.csv) %>% 
-#      t() %>% 
-#      `row.names<-`(NULL) %>% 
-#      data.frame() %>%
-#      mutate_all(as.numeric) %>%
-#      mutate(method = "svm") %>% 
-#      melt(id.vars = c("method","samplenum"))
-#
-#    gg.quasi.input = rbind(deseq.quasi.input, 
-#                            edger.quasi.input,
-#                            wilcox.quasi.input,
-#                            svm.quasi.input)
-#  } else {
-    gg.quasi.input = rbind(deseq.quasi.input, 
-                            edger.quasi.input,
-                            wilcox.quasi.input)
-#}
+  gg.quasi.input = rbind(
+    read_quasis("deseq",  "DESeq2"),
+    read_quasis("edger",  "edgeR"),
+    read_quasis("wilcox", "Wilcoxon")
+  )
 
   gg.quasi = ggplot(gg.quasi.input, aes(x = method, y = value)) +
     geom_point(size = 3, alpha = 0.7) +
     scale_y_continuous(limits = c(0,1)) +
-    labs(x = "Method",y = "Replicates per group") +
+    labs(x = "Method", y = "Replicates per group") +
     facet_grid(samplenum~variable) +
     theme_bw() +
     theme(strip.background = element_blank())
 
-  ggsave(gg.quasi, 
+  ggsave(gg.quasi,
      filename = "quasi_plot.pdf",
      device = "pdf", bg = "transparent",
-     width =  35, height = 20, units = "cm")
+     width = 35, height = 20, units = "cm")
   """
 }

--- a/modules/quasi_plots.nf
+++ b/modules/quasi_plots.nf
@@ -11,6 +11,7 @@ process QUASI_PLOTS{
   output:
   path "quasi_plot.pdf"
 
+  script:
   """
   #!/usr/bin/env Rscript
   library("tidyverse", quietly = TRUE)

--- a/modules/svc_basic.nf
+++ b/modules/svc_basic.nf
@@ -67,7 +67,7 @@ process SVC_BASIC{
       cv=cv,
       scoring="accuracy",
       min_features_to_select=1,
-      n_jobs=-1,
+      n_jobs=$params.njobs,
       verbose=2
   )
 

--- a/modules/svc_fullsynth.nf
+++ b/modules/svc_fullsynth.nf
@@ -73,7 +73,7 @@ process SVC_FULLSYNTH{
         cv=cv,
         scoring="accuracy",
         min_features_to_select=1,
-        n_jobs=-1,
+        n_jobs=$params.njobs,
         verbose=2
     )
 

--- a/modules/svc_fullsynth_postprocess.nf
+++ b/modules/svc_fullsynth_postprocess.nf
@@ -38,7 +38,13 @@ process SVC_FULLSYNTH_POSTPROCESS{
     allgenes = row.names(inframe)
     truelabels = as.numeric(allgenes %in% truedegs)
     labels = as.numeric(allgenes %in% degs)
-    AUC = auc(truelabels, labels)
+    # If all genes are selected (e.g. in pare mode), the predictor has no variation
+    # and AUC is undefined — treat as no discrimination ability (AUC = 0.5)
+    if (length(unique(truelabels)) < 2) {
+      AUC = 0.5
+    } else {
+      AUC = auc(truelabels, labels)
+    }
     # Remember that 0.5 = a truly random ROC, so for best effect we do (0.5-AUC)*2
     normAUC = (AUC-0.5)*2 # Greater deviation from 0 = better discrimination
 

--- a/modules/svc_permute.nf
+++ b/modules/svc_permute.nf
@@ -66,7 +66,7 @@ process SVC_PERMUTE{
         cv=cv,
         scoring="accuracy",
         min_features_to_select=1,
-        n_jobs=-1,
+        n_jobs=$params.njobs,
         verbose=2
     )
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,5 @@
-process.container = 'docker://benjaminataylor/zuzu:latest'
+process.container = 'benjaminataylor/zuzu:latest'
+docker.enabled = true
 
 process {
     withLabel: small_job {
@@ -13,7 +14,21 @@ process {
     }
     withLabel: big_job {
         cpus = 10
-        memory = '15 GB'
+        memory = '20 GB'
         time = '1d'
+    }
+}
+
+profiles {
+    local {
+        params.njobs = 1
+    }
+    cluster {
+        params.njobs = -1
+        process {
+            withLabel: big_job {
+                memory = '30 GB'
+            }
+        }
     }
 }

--- a/testcommand
+++ b/testcommand
@@ -1,21 +1,22 @@
-nextflow run main.nf \
-   #--samplesheet "input/test3/samplesheet_phenotype.csv" \
-   #--countsframe "input/test3/GSE91061_BMS038109Sample.hg19KnownGene.raw.tsv" \
-   #--reflevel "Pre-treatment" \
-    --samplesheet "input/test2/samplesheet_phenotype.csv" \
-    --countsframe "input/test2/salmon.merged.gene_counts.tsv" \
-    --reflevel "nurse" \
-    --outdir "output" \
-    --nperms 3 \
-    --truecutoff 0.00001 \
-    --synthstep true \
-    --synthdeg_pct 0.1 \
-    --mlstep false \
-    --pareml true \
-    -w work \
-    -resume
+#nextflow run main.nf \
+#   #--samplesheet "input/test3/samplesheet_phenotype.csv" \
+#   #--countsframe "input/test3/GSE91061_BMS038109Sample.hg19KnownGene.raw.tsv" \
+#   #--reflevel "Pre-treatment" \
+#    --samplesheet "input/test2/samplesheet_phenotype.csv" \
+#    --countsframe "input/test2/salmon.merged.gene_counts.tsv" \
+#    --reflevel "nurse" \
+#    --outdir "output" \
+#    --nperms 3 \
+#    --truecutoff 0.00001 \
+#    --synthstep true \
+#    --synthdeg_pct 0.1 \
+#    --mlstep false \
+#    --pareml true \
+#    -w work \
+#    -resume
     
 nextflow run main.nf \
+    -profile local \
     --samplesheet "input/test5/samplesheet.csv" \
     --countsframe "input/test5/salmon.merged.gene_counts.tsv" \
     --reflevel "nurse" \
@@ -25,7 +26,7 @@ nextflow run main.nf \
     --synthstep true \
     --synthdeg_pct 0.1 \
     --mlstep true \
-    --pareml true \
+    --pareml false \
     --stepsize 10 \
     -w work \
     -resume


### PR DESCRIPTION
## Summary
- Replace `val` string-list inputs with `path`+`stageAs` in plotting modules
  (`fullsynth_plots`, `permute_hists`, `quasi_plots`), removing brittle regex
  string-parsing in favour of `list.files()` on staged subdirectories
- Add `local` and `cluster` Nextflow profiles; SVC modules now use
  `params.njobs` instead of hardcoded `n_jobs=-1`
- Fix edge case where AUC is undefined when all genes are selected (pare mode)
- Fix Docker container string format and enable Docker in config; bump
  `big_job` memory to 20 GB (30 GB on cluster profile)
- Add Dockerfiles and R/Python dependency lists to the repo
- Nextflow linting fixes
